### PR TITLE
Anh's Newsfeed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /yarn-error.log
 
 .byebug_history
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,5 @@ gem 'turbolinks'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier'
 gem 'web-console', group: :development
+
+gem "tailwindcss-rails", "~> 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,14 @@ gem 'uglifier'
 gem 'web-console', group: :development
 
 gem "tailwindcss-rails", "~> 2.0"
+# Http Requests [https://github.com/httprb/http]
+gem "http"
+# Pagination [https://github.com/kaminari/kaminari]
+gem "kaminari"
+
+group :development, :test do
+  gem "factory_bot_rails"
+  gem "shoulda-matchers"
+  gem "webmock"
+  gem "faker"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -100,19 +102,55 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.11.0)
     execjs (2.8.1)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (3.2.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
+    http (5.1.1)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -224,6 +262,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     spring (4.1.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
@@ -245,6 +285,9 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -252,6 +295,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -268,7 +315,11 @@ DEPENDENCIES
   capybara
   coffee-rails
   devise
+  factory_bot_rails
+  faker
+  http
   jbuilder
+  kaminari
   listen
   pg
   pry-rails
@@ -277,12 +328,14 @@ DEPENDENCIES
   rspec-rails
   sass-rails
   selenium-webdriver
+  shoulda-matchers
   spring
   tailwindcss-rails (~> 2.0)
   turbolinks
   tzinfo-data
   uglifier
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,8 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     strscan (3.0.4)
+    tailwindcss-rails (2.0.29)
+      railties (>= 6.0.0)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.0)
@@ -276,6 +278,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   spring
+  tailwindcss-rails (~> 2.0)
   turbolinks
   tzinfo-data
   uglifier

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails tailwindcss:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
 @layer components {
-  .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
+  a:hover {
+    @apply text-yellow; 
+  }
+  .btn {
+    @apply text-base px-6 py-2 h-12 leading-4 rounded-lg transition-all border-4;
+  }
+  .primary {
+    @apply text-white bg-primary border-primary;
+  }
+  .white {
+    @apply bg-white border-primary;
+  }
+  .btn:hover {
+    @apply text-primary bg-yellow border-yellow;
+  }
+  form {
+    @apply inline-block;
   }
 }
-
-*/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def authenticate_user!
+    redirect_to new_user_session_path unless current_user
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,2 +1,0 @@
-class PagesController < ApplicationController
-end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,0 +1,27 @@
+class StoriesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @stories = Story.page(params[:page]).per(20)
+  end
+  
+  # to improve the UX, I would switch the starring action to be asychronous
+  def star
+    story = Story.find_by(id: params[:id])
+    starred_story = UserStory.find_or_initialize_by(user: current_user, story: story)
+
+    if starred_story.save
+      flash[:notice] = "Story saved successfully."
+    end
+    redirect_to starred_stories_path
+  end
+
+  def starred
+    @stories = Story.select('stories.*, COUNT(user_stories.id) AS user_story_count').
+                    joins(:user_stories).
+                    includes(:users).
+                    group('stories.id').
+                    order('user_story_count DESC').
+                    page(params[:page]).per(20)
+  end
+end

--- a/app/jobs/fetch_top_stories_job.rb
+++ b/app/jobs/fetch_top_stories_job.rb
@@ -1,0 +1,8 @@
+class FetchTopStoriesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    HackerNews.fetch_and_save_to_stories
+  end
+end
+

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,0 +1,9 @@
+class Story < ApplicationRecord
+  validates :title, presence: true
+  validates :url, presence: true
+  validates :reference_id, presence: true, uniqueness: true
+
+  has_many :user_stories
+  has_many :users, through: :user_stories
+end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,11 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :user_stories
+  has_many :stories, through: :user_stories
+
+  def name
+    "#{first_name} #{last_name}"
+  end
 end

--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -1,0 +1,4 @@
+class UserStory < ApplicationRecord
+  belongs_to :user
+  belongs_to :story
+end

--- a/app/services/hacker_news.rb
+++ b/app/services/hacker_news.rb
@@ -1,0 +1,49 @@
+require "http"
+
+class HackerNews
+  TOP_STORIES_URL = "https://hacker-news.firebaseio.com/v0/topstories.json"
+  STORY_DETAILS_URL = "https://hacker-news.firebaseio.com/v0/item/"
+  TOP_STORIES_FETCH_LIMIT = 100
+  
+  # over time, we will have many old news stories
+  # as an improvement, we could check the posted_at timestamp and
+  # delete any stories not starred/ posted more than 1 week ago 
+  def self.fetch_and_save_to_stories
+    story_ids = get_top_story_ids.first(TOP_STORIES_FETCH_LIMIT)
+
+    return if !story_ids
+
+    story_ids.each do |story_id|
+      # update all stories (in case URL or other relevant data has changed)
+      story = Story.find_or_initialize_by(reference_id: story_id)
+      story_details = get_story_details(story_id)
+      if story_details
+        story.title = story_details["title"]
+        story.url = story_details["url"]
+        story.posted_at = Time.at(story_details["time"]).utc
+        story.author = story_details["by"]
+        story.save
+      end
+    end
+  end
+
+  def self.get_top_story_ids
+    response = HTTP.get(TOP_STORIES_URL)
+    if response.status.success?
+      JSON.parse(response.body)
+    else
+      Rails.logger.error("Error getting top story ids - status: #{response.status}, body: #{response.body}")
+      return
+    end
+  end
+
+  def self.get_story_details(story_id)
+    response = HTTP.get(STORY_DETAILS_URL + "#{story_id}" + ".json")
+    if response.status.success?
+      JSON.parse(response.body)
+    else
+      Rails.logger.error("Error getting top story details - status: #{response.status}, body: #{response.body}")
+      return
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
     <title>Top News</title>
     <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,12 +9,15 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>
-    <p class="notice">
-      <%= notice %>
-    </p>
-    <p class="alert">
-      <%= alert %>
-    </p>
-    <%= yield %>
+    <main class="min-h-screen px-6 py-6 bg-off-white">
+      <p class="notice">
+        <%= notice %>
+      </p>
+      <p class="alert">
+        <%= alert %>
+      </p>
+      <%= render partial: "layouts/shared/nav" %>
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/layouts/shared/_nav.html.erb
+++ b/app/views/layouts/shared/_nav.html.erb
@@ -1,0 +1,14 @@
+<div class="text-right pb-6">
+  <% if user_signed_in? %>
+    <% if request.path == starred_stories_path %>
+      <%= link_to 'Top Stories', root_path, class: "btn white" %>
+    <% else %>
+      <%= link_to 'Starred Stories', starred_stories_path, class: "btn white" %>
+    <% end %>
+    <%= button_to 'Logout', destroy_user_session_path, method: :delete, class: "btn primary" %>
+  <% else %>
+    <%= link_to 'Sign Up', new_user_registration_path, class: "btn primary #{'hidden' if request.path == new_user_registration_path }" %>
+    <%= link_to 'Login', new_user_session_path, class: "btn white #{'hidden' if request.path == new_user_session_path }" %>
+  <% end %>
+</div>
+

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,1 +1,0 @@
-<h1>Welcome to Top News</h1>

--- a/app/views/stories/_story_list.html.erb
+++ b/app/views/stories/_story_list.html.erb
@@ -1,0 +1,37 @@
+<table class="table-auto w-full border-t p-5">
+  <thead>
+    <tr class="bg-yellow text-left">
+      <th></th>
+      <th class="p-4 text-sm font-medium">Hacker News</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @stories.each do |story| %>
+      <tr>
+        <td class="text-center">
+          <% if current_user.stories.include?(story) %>
+            <span class="text-xs">Saved!</span>
+          <% else %>
+            <%= button_to star_story_path(story), method: :post do %>
+              <svg aria-hidden="true" class="w-6 h-6 hover:text-yellow" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <title>Star Story</title>
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
+              </svg>
+              <span class="sr-only">Star Story</span>
+            <% end %>
+          <% end %>
+        </td>
+        <td class="border-t px-4 py-5 text-sm font-normal">
+          <%= link_to story.title, story.url %>
+          <p class="text-xs text-gray-600">
+            Posted <%= time_ago_in_words(Time.at(story.posted_at).utc) %> ago
+          </p>
+          <p class="text-xs text-gray-600">
+            <%= story.users.map(&:name).join(", ") %>
+          </p>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -1,0 +1,10 @@
+<h1 class="p-4">Welcome to Top News</h1>
+
+<%= render partial: 'stories/story_list',
+            locals: { stories: @stories } %>
+
+<div class="text-right">
+  <%= paginate @stories, window: 2 %>
+  <%= page_entries_info @stories, entry_name: 'story' %>
+</div>
+

--- a/app/views/stories/starred.html.erb
+++ b/app/views/stories/starred.html.erb
@@ -1,0 +1,10 @@
+<h1 class="p-4">Starred News Stories</h1>
+
+<%= render partial: 'stories/story_list',
+            locals: { stories: @stories } %>
+
+<div class="text-right">
+  <%= paginate @stories, window: 2 %>
+  <%= page_entries_info @stories, entry_name: 'starred story' %>
+</div>
+

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Topnews
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: 'pages#home'
+  root to: 'stories#index'
+
+  resources :stories, only: [:index] do
+    post 'star', on: :member
+  end
+  get 'starred_stories', to: 'stories#starred', as: :starred_stories
 end

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,23 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/aspect-ratio'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ]
+}

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -12,6 +12,11 @@ module.exports = {
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
       },
+      colors: {
+        'primary': '#2f2d2f',
+        'yellow': '#ecbe07',
+        'off-white': '#fcfaf6',
+      },
     },
   },
   plugins: [

--- a/db/migrate/20230601162554_create_stories.rb
+++ b/db/migrate/20230601162554_create_stories.rb
@@ -1,0 +1,13 @@
+class CreateStories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :stories do |t|
+      t.string :title
+      t.string :url
+      t.string :author
+      t.datetime :posted_at
+      t.integer :reference_id, null: false
+      t.timestamps
+    end
+    add_index :stories, :reference_id, unique: true
+  end
+end

--- a/db/migrate/20230601163414_create_user_stories.rb
+++ b/db/migrate/20230601163414_create_user_stories.rb
@@ -1,0 +1,10 @@
+class CreateUserStories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_stories do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :story, index: true, foreign_key: true
+      t.timestamps
+    end
+    add_index :user_stories, [:story_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2018_02_28_212101) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_01_163414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "stories", force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.string "author"
+    t.datetime "posted_at"
+    t.integer "reference_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reference_id"], name: "index_stories_on_reference_id", unique: true
+  end
+
+  create_table "user_stories", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "story_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["story_id", "user_id"], name: "index_user_stories_on_story_id_and_user_id", unique: true
+    t.index ["story_id"], name: "index_user_stories_on_story_id"
+    t.index ["user_id"], name: "index_user_stories_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"
@@ -33,4 +54,6 @@ ActiveRecord::Schema[7.0].define(version: 2018_02_28_212101) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "user_stories", "stories"
+  add_foreign_key "user_stories", "users"
 end

--- a/lib/tasks/fetch_and_save_top_stories.rake
+++ b/lib/tasks/fetch_and_save_top_stories.rake
@@ -1,0 +1,11 @@
+namespace :hacker_news do
+  desc "Fetch top stories from Hacker News API and save stories"
+  # rake hacker_news:fetch_and_save_top_stories 
+  # this rake task can be added to Heroku scheduler 
+  # https://elements.heroku.com/addons/scheduler
+  # it can be ran hourly or daily as needed to fetch updated data
+  task fetch_and_save_top_stories: :environment do
+      FetchTopStoriesJob.perform_later
+  end
+end
+

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :story do
+    title { Faker::Lorem.sentence }
+    url { Faker::Internet.url }
+    author { Faker::Lorem.word }
+    posted_at { 1.day.ago }
+    reference_id { Faker::Number.binary(digits: 8) }
+  end
+end
+

--- a/spec/factories/user_story.rb
+++ b/spec/factories/user_story.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user_story do
+    user
+    story
+  end
+end
+

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    first_name { Faker::Name.name }
+    last_name  { Faker::Name.name  }
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
+  end
+end
+

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Story, type: :model do
+
+  describe 'associations' do
+    it { should have_many(:user_stories) }
+    it { should have_many(:users).through(:user_stories) }
+  end
+
+  describe "validations" do
+    it "is valid with a title and url and reference_id" do
+      story = FactoryBot.build(:story)
+      expect(story).to be_valid
+    end
+
+    it "is invalid without a reference_id" do
+      story = FactoryBot.build(:story, reference_id: nil)
+      expect(story).not_to be_valid
+    end
+
+    it "is invalid without a url" do
+      story = FactoryBot.build(:story, url: nil)
+      expect(story).not_to be_valid
+    end
+
+    it "is invalid without a title" do
+      story = FactoryBot.build(:story, title: nil)
+      expect(story).not_to be_valid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,17 +1,17 @@
-require 'rails_helper'
+require "rails_helper"
 
-describe User do
-  context "creating a new user" do
-    let(:attrs) do
-      { first_name: :foo, last_name: :bar, email: 'f@b.c', password: 'foobar123' }
-    end
+RSpec.describe User, :type => :model do
 
-    it "should have first, last, email" do
-      expect { User.create(attrs) }.to change{ User.count }.by(1)
-    end
+  describe 'associations' do
+    it { should have_many(:user_stories) }
+    it { should have_many(:stories).through(:user_stories) }
+  end
 
-    it "should require a password" do
-      expect(User.new(attrs.except(:password))).to be_invalid
+  describe "#name" do
+    it "returns user first and last name" do
+      u = create(:user, first_name: "Anh", last_name: "Larusso")
+      expect(u.name).to eq("Anh Larusso")
     end
   end
 end
+

--- a/spec/models/user_story_spec.rb
+++ b/spec/models/user_story_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe UserStory, type: :model do
+
+  describe 'associations' do
+    it { should belong_to(:user) }
+    it { should belong_to(:story) }
+  end
+end
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,8 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'webmock/rspec'
+require_relative 'support/factory_bot'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -29,6 +31,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
@@ -54,4 +57,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe "Stories", type: :request do
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:story) { FactoryBot.create(:story) }
+
+  before do
+    sign_in user
+  end
+  
+  describe "GET /index" do
+    it "returns a successful response" do
+      get stories_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns list of stories" do
+      story1 = FactoryBot.create(:story)
+      story2 = FactoryBot.create(:story)
+      get stories_path
+      expect(response.body).to include(story1.title)
+      expect(response.body).to include(story2.title)
+    end
+  end
+
+  describe 'POST /star' do
+    context "with valid params" do
+      it "creates a UserStory record" do
+        expect {
+          post star_story_path(story), params: { id: story.id }
+        }.to change(UserStory, :count).by(1)
+        expect(UserStory.last.user).to eq user
+        expect(UserStory.last.story).to eq story
+      end
+
+      it "redirects to the starred stories page" do
+        post star_story_path(story), params: { id: story.id }
+        expect(response).to redirect_to(starred_stories_path)
+      end
+    end
+
+    context "with invalid params" do
+      it "does not create a UserStory" do
+        post "/stories/100/star", params: { id: 100 }
+        expect(UserStory.count).to eq 0
+      end
+    end
+  end
+
+  describe "GET /starred" do
+    it "returns a successful response" do
+      get starred_stories_path
+      expect(response).to be_successful
+    end
+
+    it "returns list of starred stories with user name" do
+      FactoryBot.create(:user_story, story: story, user: user)
+      get starred_stories_path
+      expect(response.body).to include(story.title)
+      expect(response.body).to include(user.name)
+    end
+
+    it "does not return stories that are not starred" do
+      get starred_stories_path
+      expect(response.body).to_not include(story.title)
+    end
+  end
+end

--- a/spec/services/hacker_news_spec.rb
+++ b/spec/services/hacker_news_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe HackerNews do
+  include ActiveJob::TestHelper
+
+  let(:story_ids_response) do
+    [36155204].to_json
+  end
+
+  let(:story_details_response) do
+    {
+      'id': 36155204,
+      'title': 'Was Modern Art a CIA Psy-Op?',
+      'url': 'https://daily.jstor.org/was-modern-art-really-a-cia-psy-op/',
+      'by': 'areoform',
+      'time': 1175714200
+    }.to_json
+  end
+
+  let(:null_story_details_response) do
+    {}.to_json
+  end
+
+  describe ".fetch_and_save_to_stories" do
+
+    context "when request is successful" do
+      it "fetches stories and saves record" do
+        ids_url = "https://hacker-news.firebaseio.com/v0/topstories.json"
+        WebMock.stub_request(:get, ids_url).to_return({ body: story_ids_response })
+        details_url = "https://hacker-news.firebaseio.com/v0/item/36155204.json"
+        WebMock.stub_request(:get, details_url).to_return({ body: story_details_response })
+        HackerNews.fetch_and_save_to_stories
+        expect(Story.count).to eq(1)
+        story = Story.first
+        expect(story.title).to eq("Was Modern Art a CIA Psy-Op?")
+        expect(story.author).to eq("areoform")
+        expect(story.url).to eq("https://daily.jstor.org/was-modern-art-really-a-cia-psy-op/")
+        expect(story.reference_id).to eq(36155204)
+        expect(story.posted_at).to eq(Time.at(1175714200).utc)
+      end
+    end
+
+    context "when request failed" do
+      it "does not create a new story" do
+        ids_url = "https://hacker-news.firebaseio.com/v0/topstories.json"
+        WebMock.stub_request(:get, ids_url).to_return({ body: story_ids_response })
+        details_url = "https://hacker-news.firebaseio.com/v0/item/36155204.json"
+        WebMock.stub_request(:get, details_url).to_return({ status: 500, body: "error" })
+        HackerNews.fetch_and_save_to_stories
+        expect(Story.count).to eq(0)
+      end
+    end
+  end
+
+  describe ".get_top_story_ids" do    
+    context "when request fails" do
+      it "returns an error" do
+        ids_url = "https://hacker-news.firebaseio.com/v0/topstories.json"
+        WebMock.stub_request(:get, ids_url).to_return({ status: 500, body: "error" })
+        expect(Rails.logger).to receive(:error).with("Error getting top story ids - status: 500 Internal Server Error, body: error")
+        HackerNews.get_top_story_ids
+      end
+    end
+
+    context "when request succeeds" do
+      it "fetches list of top story ids" do
+        ids_url = "https://hacker-news.firebaseio.com/v0/topstories.json"
+        request = WebMock.stub_request(:get, ids_url).to_return({ body: story_ids_response })
+        expect(request.response.body).to include("36155204")
+        HackerNews.get_top_story_ids
+      end
+    end
+  end
+
+  describe ".get_story_details" do
+    let(:story) { FactoryBot.create(:story) }
+
+    context "when request fails" do
+      it "returns an error" do
+        details_url = "https://hacker-news.firebaseio.com/v0/item/36155204.json"
+        WebMock.stub_request(:get, details_url).to_return({ status: 500, body: "error" })
+        expect(Rails.logger).to receive(:error).with("Error getting top story details - status: 500 Internal Server Error, body: error")
+        HackerNews.get_story_details(36155204)
+      end
+    end
+
+    context "when request succeeds" do
+      it "fetches details for story" do
+        details_url = "https://hacker-news.firebaseio.com/v0/item/36155204.json"
+        request = WebMock.stub_request(:get, details_url).to_return({ body: story_details_response })
+        expect(request.response.body).to include("title")
+        expect(request.response.body).to include("url")
+        expect(request.response.body).to include("id")
+        expect(request.response.body).to include("by")
+        expect(request.response.body).to include("time")
+        HackerNews.get_story_details(36155204)
+      end
+    end
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end
+


### PR DESCRIPTION
Note: in order to make it easier to review this PR, I have split out the tailwind init code to a separate commit.  [This commit](https://github.com/fscbco/topnews/commit/6f9a40328000b2313050ac8e559d1f3c27afa2fd) contains my changes.

# Overview:
- This PR creates a story index page, which lists the current top Hacker News stories
- The stories can be updated continuously when rake task is added to a scheduler (i.e. Heroku Scheduler, or Resque, Sidekiq, etc)
- All views require users to be authenticated
- Users can view stories and click to 'star' stories
- 'Starred' stories appear on a separate page, which is ordered by most starred and shows the names of users who starred it

# Possible areas of improvement:
- Moving the 'starring' action to be asynchronous would improve the UX. Right now, the user is redirected to the starred stories page after starring a story - they may want to remain on the index page to continue browsing.
- As mentioned above, to continuously update the stories list - we would need to call the rake task using a cronjob or some other scheduler.
- It may not be necessary to retain all stories. One option is to prune old stories that have not been saved. Another option is to implement a Redis cache that contains recently fetched stories.  Only starred stories would then be saved to the db.