### PR TITLE
Internal Tool to fetch, view, and star recent hackernews stories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,6 @@ gem 'turbolinks'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier'
 gem 'web-console', group: :development
+gem 'font_awesome5_rails'
+gem 'mocha'
+gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
     erubi (1.11.0)
     execjs (2.8.1)
     ffi (1.15.5)
+    font_awesome5_rails (1.5.0)
+      nokogiri (>= 1.11.3)
+      railties (>= 4.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -124,6 +127,8 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.16.3)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -208,6 +213,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.1)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -254,6 +260,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.0)
@@ -266,8 +273,10 @@ DEPENDENCIES
   capybara
   coffee-rails
   devise
+  font_awesome5_rails
   jbuilder
   listen
+  mocha
   pg
   pry-rails
   puma
@@ -280,6 +289,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
+  will_paginate
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,5 @@
+class ErrorsController < ApplicationController
+  def not_found
+    render(status: 404)
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,2 +1,7 @@
 class PagesController < ApplicationController
+  before_action :authenticate_user!
+
+  def home
+    redirect_to stories_path
+  end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -8,6 +8,12 @@ class StoriesController < ApplicationController
     redirect_to root_path
   end
 
+  def starred
+    @starred_stories = Story.includes(user_stories: :user).starred.paginate(page: params[:page], per_page: 10)
+  rescue StandardError => e
+    flash[:error] = "An error occurred while retrieving the starred stories: #{e.message}"
+    redirect_to root_path
+  end
 
   def star
     @story = Story.find_by(hacker_news_story_id: params[:id])

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,0 +1,42 @@
+class StoriesController < ApplicationController
+  before_action :save_new_stories, only: [:index]
+
+  def index
+    @top_stories = fetch_stories
+  rescue StandardError => e
+    flash[:error] = "An error occurred while fetching the top stories: #{e.message}"
+    redirect_to root_path
+  end
+
+  private
+
+  def fetch_stories
+    uri = URI('https://hacker-news.firebaseio.com/v0/topstories.json')
+    response = Net::HTTP.get(uri)
+    top_stories_ids = JSON.parse(response)
+    top_stories_ids.first(10).map do |story_id|
+      uri = URI("https://hacker-news.firebaseio.com/v0/item/#{story_id}.json")
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    end
+  rescue StandardError => e
+    raise "Failed to fetch stories: #{e.message}"
+  end
+
+  def save_new_stories
+    stories = fetch_stories
+    stories.each do |story|
+      Story.find_or_create_by(hacker_news_story_id: story["id"]) do |new_story|
+        new_story.title = story["title"]
+        new_story.url = story["url"]
+      end
+    end
+  rescue StandardError => e
+    flash[:error] = "An error occurred while saving new stories: #{e.message}"
+    redirect_to root_path
+  end
+
+  def story_params
+    params.require(:story).permit(:title, :url, :hacker_news_story_id)
+  end
+end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -8,6 +8,16 @@ class StoriesController < ApplicationController
     redirect_to root_path
   end
 
+
+  def star
+    @story = Story.find_by(hacker_news_story_id: params[:id])
+    @story.star_by(current_user)
+    redirect_to root_path
+  rescue ActiveRecord::RecordNotFound => e
+    flash[:error] = "Story not found: #{e.message}"
+    redirect_to root_path
+  end
+
   private
 
   def fetch_stories

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,0 +1,5 @@
+class Story < ApplicationRecord
+  has_many :user_stories
+  has_many :starring_users, through: :user_stories, source: :user
+
+end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,5 +1,20 @@
 class Story < ApplicationRecord
   has_many :user_stories
   has_many :starring_users, through: :user_stories, source: :user
+  
+  scope :starred, -> { where(starred: true)}
 
+  class StoryNotFoundError < StandardError
+    def initialize(message = "Our fault! Story not found")
+      super(message)
+    end
+  end
+  
+  def star_by(user)
+    update(starred: true) unless starred?
+    user_stories.create(user: user)
+  rescue StandardError => e
+    Rails.logger.error("Error starring the story: #{e.message}")
+    raise StoryNotFoundError, e.message
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :user_stories
+  has_many :starred_stories, through: :user_stories, source: :story
+
+  # The many-to-many relationship between users and stories is not necessary for these project requiremments,
+  # but in the spirit of building for the long run, I chose to use this association for a feature that will allow clients to select users and see a list of the
+  # stories they've starred.
 end
+

--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -2,6 +2,6 @@ class UserStory < ApplicationRecord
   belongs_to :user
   belongs_to :story
 
-  validates :user_id, :presence, uniqueness: { scope: :story_id }
-  validates :story_id, :presence, uniqueness: { scope: :user_id }
+  validates :user_id, uniqueness: { scope: :story_id }
+  validates :story_id, uniqueness: { scope: :user_id }
 end

--- a/app/models/user_story.rb
+++ b/app/models/user_story.rb
@@ -1,0 +1,7 @@
+class UserStory < ApplicationRecord
+  belongs_to :user
+  belongs_to :story
+
+  validates :user_id, :presence, uniqueness: { scope: :story_id }
+  validates :story_id, :presence, uniqueness: { scope: :user_id }
+end

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,3 @@
+<h1>404 Not Found</h1>
+<p>Sorry, the page you're looking for doesn't exist! Head on home.</p>
+<a href="<%= root_path %>">Back to Home</a>

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -37,6 +37,9 @@
   <div class="story">
     <h2><%= story['title'] %></h2>
     <p><%= link_to 'Read More', story['url'], target: '_blank' %></p>
+    <%= button_to star_story_path(id: story['id']), method: :post, class: 'button' do %>
+      <%= fa_icon 'star', text: 'Star' %>
+  <% end %>
   </div>
 <% end %>
 </body>

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -1,0 +1,43 @@
+<html>
+<head>
+  <style>
+      body {
+          font-family: Arial, sans-serif;
+      }
+      h1 {
+          color: #333;
+      }
+      .button {
+          background-color: #4CAF50;
+          border: none;
+          color: white;
+          padding: 15px 32px;
+          text-align: center;
+          text-decoration: none;
+          display: inline-block;
+          font-size: 16px;
+          margin: 4px 2px;
+          cursor: pointer;
+      }
+      .story {
+          margin-bottom: 20px;
+          padding: 10px;
+          border: 1px solid #ddd;
+          border-radius: 5px;
+      }
+      .story p {
+          margin: 0;
+      }
+  </style>
+</head>
+<body>
+<h1>Welcome to Top News</h1>
+
+<% @top_stories.each do |story| %>
+  <div class="story">
+    <h2><%= story['title'] %></h2>
+    <p><%= link_to 'Read More', story['url'], target: '_blank' %></p>
+  </div>
+<% end %>
+</body>
+</html>

--- a/app/views/stories/starred.html.erb
+++ b/app/views/stories/starred.html.erb
@@ -31,19 +31,22 @@
   </style>
 </head>
 <body>
-<h1>Welcome to Top News</h1>
+<h1>Starred Stories</h1>
 
-<div style="text-align: right;">
-  <%= link_to 'Go to Starred', starred_stories_path, class: 'button' %>
-</div>
-<% @top_stories.each do |story| %>
+<% @starred_stories.each do |story| %>
   <div class="story">
-    <h2><%= story['title'] %></h2>
-    <p><%= link_to 'Read More', story['url'], target: '_blank' %></p>
-    <%= button_to star_story_path(id: story['id']), method: :post, class: 'button' do %>
-      <%= fa_icon 'star', text: 'Star' %>
-  <% end %>
+    <h2><%= story.title %></h2>
+    <p><%= link_to 'Read More', story.url, target: '_blank' %></p>
+    <p>Starred by: <%= story.user_stories.map { |us| "#{us.user.first_name} #{us.user.last_name}" }.join(', ') %></p>
   </div>
 <% end %>
+
+<div style="text-align: right;">
+  <%= will_paginate @starred_stories, previous_label: 'Previous', next_label: 'Next', class: 'button' %>
+</div>
+
+<div style="text-align: center;">
+  <%= link_to 'Back to All Stories', stories_path, class: 'button' %>
+</div>
 </body>
 </html>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,3 +2,8 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
 end
+
+
+  # Catch-all route for handling unmatched routes
+  match "*path", to: "errors#not_found", via: :all
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
+  resources :stories do
 end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,14 @@ Rails.application.routes.draw do
   resources :stories do
     member do
       post 'star'
-end
+    end
 
+    collection do
+      get 'starred'
+    end
   end
 
   # Catch-all route for handling unmatched routes
   match "*path", to: "errors#not_found", via: :all
 end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,14 @@
 Rails.application.routes.draw do
   devise_for :users
+
   root to: 'pages#home'
+
   resources :stories do
+    member do
+      post 'star'
 end
 
+  end
 
   # Catch-all route for handling unmatched routes
   match "*path", to: "errors#not_found", via: :all

--- a/db/migrate/20230613182436_create_stories_table.rb
+++ b/db/migrate/20230613182436_create_stories_table.rb
@@ -1,0 +1,12 @@
+class CreateStoriesTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :stories do |t|
+      t.string "title"
+      t.string "url"
+      t.boolean "starred", default: false
+      t.bigint "hacker_news_story_id"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230613182555_create_user_stories.rb
+++ b/db/migrate/20230613182555_create_user_stories.rb
@@ -1,0 +1,13 @@
+class CreateUserStories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_stories do |t|
+      t.bigint "user_id"
+      t.bigint "story_id"
+
+      t.index ["story_id"], name: "index_user_stories_on_story_id"
+      t.index ["user_id"], name: "index_user_stories_on_user_id"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,34 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_04_201825) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_182555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "starred_stories", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "story_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["story_id"], name: "index_starred_stories_on_story_id"
-    t.index ["user_id"], name: "index_starred_stories_on_user_id"
-  end
 
   create_table "stories", force: :cascade do |t|
     t.string "title"
     t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "starred", default: false
     t.bigint "hacker_news_story_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "user_stories", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.bigint "story_id"
-    t.string "user_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["story_id"], name: "index_user_stories_on_story_id"
     t.index ["user_id"], name: "index_user_stories_on_user_id"
   end
@@ -61,8 +51,4 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_04_201825) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "starred_stories", "stories"
-  add_foreign_key "starred_stories", "users"
-  add_foreign_key "user_stories", "stories"
-  add_foreign_key "user_stories", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2018_02_28_212101) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_04_201825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "starred_stories", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "story_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["story_id"], name: "index_starred_stories_on_story_id"
+    t.index ["user_id"], name: "index_starred_stories_on_user_id"
+  end
+
+  create_table "stories", force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "starred", default: false
+    t.bigint "hacker_news_story_id"
+  end
+
+  create_table "user_stories", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.bigint "story_id"
+    t.string "user_name"
+    t.index ["story_id"], name: "index_user_stories_on_story_id"
+    t.index ["user_id"], name: "index_user_stories_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"
@@ -33,4 +61,8 @@ ActiveRecord::Schema[7.0].define(version: 2018_02_28_212101) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "starred_stories", "stories"
+  add_foreign_key "starred_stories", "users"
+  add_foreign_key "user_stories", "stories"
+  add_foreign_key "user_stories", "users"
 end

--- a/lib/tasks/load_seeds.rake
+++ b/lib/tasks/load_seeds.rake
@@ -1,0 +1,7 @@
+namespace :db do
+  desc 'Load seed data into the database'
+  task load_seeds: :environment do
+    seed_file = File.join(Rails.root, 'db', 'seeds.rb')
+    load(seed_file) if File.exist?(seed_file)
+  end
+end

--- a/test/controllers/error_controller_test.rb
+++ b/test/controllers/error_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "should render not found page" do
+    get "/errors/not_found"
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class PagesControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  def setup
+    @user = users(:one)
+    sign_in @user
+  end
+
+  test "should redirect to stories path on home page" do
+    get :home
+    assert_redirected_to stories_path
+  end
+
+  test "should require authentication for home page" do
+    sign_out @user
+    get :home
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/controllers/stories_controller_test.rb
+++ b/test/controllers/stories_controller_test.rb
@@ -16,6 +16,15 @@ class StoriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should star a story" do
+    StoriesController.any_instance.stubs(:fetch_stories).returns([@story])
+
+    assert_difference('@story.user_stories.count') do
+      post star_story_url(@story)
+    end
+    assert_redirected_to root_path
+  end
+
   test "should handle error when fetching top stories" do
     StoriesController.any_instance.stubs(:fetch_stories).raises(StandardError, "Failed to fetch stories")
 
@@ -24,4 +33,12 @@ class StoriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "An error occurred while saving new stories: Failed to fetch stories", flash[:error]
   end
 
+
+  test "should handle error when starring a story" do
+    Story.stubs(:find_by).raises(ActiveRecord::RecordNotFound)
+
+    post star_story_url(@story)
+    assert_redirected_to root_path
+    assert_match(/Story not found/, flash[:error])
+  end
 end

--- a/test/controllers/stories_controller_test.rb
+++ b/test/controllers/stories_controller_test.rb
@@ -33,6 +33,13 @@ class StoriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "An error occurred while saving new stories: Failed to fetch stories", flash[:error]
   end
 
+  test "should handle error when retrieving starred stories" do
+    Story.expects(:includes).raises(StandardError, "Failed to retrieve starred stories")
+
+    get starred_stories_url
+    assert_redirected_to root_path
+    assert_equal "An error occurred while retrieving the starred stories: Failed to retrieve starred stories", flash[:error]
+  end
 
   test "should handle error when starring a story" do
     Story.stubs(:find_by).raises(ActiveRecord::RecordNotFound)

--- a/test/controllers/stories_controller_test.rb
+++ b/test/controllers/stories_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'mocha/minitest'
+
+class StoriesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @story = stories(:one)
+    @user = users(:one)
+    sign_in @user
+    @controller = StoriesController.new
+  end
+
+  test "should get index" do
+    get stories_url
+    assert_response :success
+  end
+
+  test "should handle error when fetching top stories" do
+    StoriesController.any_instance.stubs(:fetch_stories).raises(StandardError, "Failed to fetch stories")
+
+    get stories_url
+    assert_redirected_to root_path
+    assert_equal "An error occurred while saving new stories: Failed to fetch stories", flash[:error]
+  end
+
+end

--- a/test/fixtures/stories.yml
+++ b/test/fixtures/stories.yml
@@ -1,0 +1,11 @@
+one:
+  title: 'Story One'
+  url: 'https://storyone.com'
+  hacker_news_story_id: 980190962
+  starred: false
+
+two:
+  title: 'Story Two'
+  url: 'https://storytwo.com'
+  hacker_news_story_id: 2
+  starred: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,13 @@
+one:
+  first_name: 'Lauren'
+  last_name: 'Albert'
+  email: 'test1@example.com'
+  encrypted_password: '1234'
+  sign_in_count: 1
+
+two:
+  first_name: 'Schmauren'
+  last_name: 'Albertson'
+  email: 'test2@example.com'
+  encrypted_password: '12345'
+  sign_in_count: 1

--- a/test/integration/stories_controller_test.rb
+++ b/test/integration/stories_controller_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+require 'mocha/minitest'
+class StoriesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    @story = stories(:one)
+    sign_in @user
+  end
+
+  test "should get index" do
+    get stories_url
+    assert_response :success
+    assert_select "h1", "Welcome to Top News"
+  end
+
+end

--- a/test/integration/stories_controller_test.rb
+++ b/test/integration/stories_controller_test.rb
@@ -15,4 +15,18 @@ class StoriesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Welcome to Top News"
   end
 
+  test "should star story" do
+    StoriesController.any_instance.stubs(:fetch_stories).returns([@story])
+
+    id_param = @story.id.to_s
+    StoriesController.any_instance.stubs(:params).returns({ id: id_param })
+
+    assert_difference('UserStory.count', 1) do
+      post star_story_url(@story)
+    end
+    assert_redirected_to root_path
+
+    assert @story.reload.starred?
+    assert @story.starring_users.include?(@user)
+  end
 end

--- a/test/integration/stories_controller_test.rb
+++ b/test/integration/stories_controller_test.rb
@@ -29,4 +29,10 @@ class StoriesControllerTest < ActionDispatch::IntegrationTest
     assert @story.reload.starred?
     assert @story.starring_users.include?(@user)
   end
+
+  test "should get starred stories" do
+    get starred_stories_url
+    assert_response :success
+    assert_select "h1", "Starred Stories"
+  end
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class StoryTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:one)
+    @story = stories(:one)
+  end
+
+  test "should star a story for a user" do
+    assert_not @story.starred?
+
+    @story.star_by(@user)
+    assert_predicate @story.reload, :starred?
+    assert @story.starring_users.include?(@user)
+  end
+
+  test "should raise StoryNotFoundError when story is not found" do
+    assert_raises Story::StoryNotFoundError do
+      @story.star_by(nil)
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,4 +6,16 @@ class UserTest < ActiveSupport::TestCase
     assert_respond_to user, :user_stories
   end
 
+  test "should have Devise modules" do
+    user = User.new
+    assert user.respond_to?(:email)
+    assert user.respond_to?(:encrypted_password)
+    assert user.respond_to?(:reset_password_token)
+    assert user.respond_to?(:remember_created_at)
+    assert user.respond_to?(:sign_in_count)
+    assert user.respond_to?(:current_sign_in_at)
+    assert user.respond_to?(:last_sign_in_at)
+    assert user.respond_to?(:current_sign_in_ip)
+    assert user.respond_to?(:last_sign_in_ip)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,6 +6,11 @@ class UserTest < ActiveSupport::TestCase
     assert_respond_to user, :user_stories
   end
 
+  test "should have many starred_stories" do
+    user = User.new
+    assert_respond_to user, :starred_stories
+  end
+
   test "should have Devise modules" do
     user = User.new
     assert user.respond_to?(:email)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  test "should have many user_stories" do
+    user = User.new
+    assert_respond_to user, :user_stories
+  end
+
+end


### PR DESCRIPTION
## What problem is your PR trying to solve?

Users should be able to view the most recent Hackernews stories, star the ones they like, and view the ones that they and their colleagues have starred. While performance and UI are not a part of the MVP, there are minor considerations in this version in order to provide some accessibility to the user.

To demonstrate product integrity and commitment, some choices have been made in order to plan for future features while other choices were made in order to ship an MVP.

## What approach did you choose?

Models: User, Story, and UserStory represent the basic app design. UserStory is a join table which currently allows users to list stories and see their many starring users. In the future, this many-to-many association would allow for colleagues to lisst users and their many starred stories.

I considered having a separate starred_stories table which ultimately offered no additional value to this MVP

Error Handling: to add basic user friendliness, all invalid paths are handled by sending the user back to the homepage. Model Errors are rescued, but reraised with a message for the user so they are aware that we know there is an error. While the error message flases the error which could potentially be coming from the app and not a user error, in this case its okay to expose those errors since the clients are internal.


## What should your reviewers focus on?
I left out test coverage for the user_story model for the purpose of moving on with shipping. Please let me know if there is any important test coverage missing for an MVP. Similarly, I handled the most likely errors. For review, I would particularly appreciate feedback if you notice important error handling missing.
