### PR TITLE
Story/create internal tool to view top stories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'byebug', platforms: [:mri, :mingw, :x64_mingw], group: [:development, :test
 gem 'capybara', group: [:development, :test]
 gem 'coffee-rails'
 gem 'devise'
+gem 'faraday'
 gem 'jbuilder'
 gem 'listen', group: :development
 gem 'pg'
@@ -20,3 +21,4 @@ gem 'turbolinks'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier'
 gem 'web-console', group: :development
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    chronic (0.10.2)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -102,6 +103,10 @@ GEM
     digest (3.1.0)
     erubi (1.11.0)
     execjs (2.8.1)
+    faraday (2.7.9)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -208,6 +213,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.1)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -254,6 +260,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.0)
@@ -266,6 +274,7 @@ DEPENDENCIES
   capybara
   coffee-rails
   devise
+  faraday
   jbuilder
   listen
   pg
@@ -280,6 +289,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
+  whenever
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :authenticate_user!
+
+  def after_sign_in_path_for(user)
+    stories_path
+  end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,0 +1,31 @@
+class StoriesController < ApplicationController
+  before_action :set_story, only: %i[ show picked ]
+
+  # GET /stories or /stories.json
+  def index
+    @stories = Story.all
+  end
+
+  # GET /stories/1 or /stories/1.json
+  def show
+  end
+
+  def picked
+    begin
+      current_user.stories << @story
+    rescue ActiveRecord::RecordInvalid => invalid
+      logger.info invalid.record.errors.messages
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_story
+      @story = Story.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def story_params
+      params.require(:story).permit(:title, :author, :external_id, :time)
+    end
+end

--- a/app/models/picked_story.rb
+++ b/app/models/picked_story.rb
@@ -1,0 +1,8 @@
+class PickedStory < ApplicationRecord
+  belongs_to :story
+  belongs_to :user
+
+  validates :story_id, uniqueness: { scope: :user_id,
+    message: "user should not picked same story more than once" }
+end
+  

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,0 +1,7 @@
+class Story < ApplicationRecord
+  has_many :picked_stories, dependent: :destroy
+  has_many :users, through: :picked_stories
+
+  validates :title, :author, :external_id, :time, presence: true
+  validates :external_id, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  
+  has_many :picked_stories, dependent: :destroy
+  has_many :stories, through: :picked_stories
 end

--- a/app/services/hacker_news_api.rb
+++ b/app/services/hacker_news_api.rb
@@ -1,0 +1,35 @@
+module HackerNewsApi
+    module V1
+      class Client
+        API_ENDPOINT = 'https://hacker-news.firebaseio.com/v0/'.freeze
+  
+        def top_stories
+           request(
+            http_method: :get,
+            endpoint: "topstories.json"
+          )
+        end
+  
+        def find_story(story_id)
+          request(
+            http_method: :get,
+            endpoint: "item/#{story_id}.json"
+          )
+        end
+  
+        private
+  
+        def client
+          @_client ||= Faraday.new(API_ENDPOINT) do |client|
+            client.request :url_encoded
+            client.adapter Faraday.default_adapter
+          end
+        end
+  
+        def request(http_method: :get, endpoint:, params: {})
+          response = client.public_send(http_method, endpoint, params)
+          JSON.parse(response.body)
+        end
+      end
+    end
+  end

--- a/app/views/stories/_story.html.erb
+++ b/app/views/stories/_story.html.erb
@@ -1,0 +1,31 @@
+<div id="<%= dom_id story %>">
+  <p>
+    <strong>Title:</strong>
+    <%= story.title %>
+  </p>
+
+  <p>
+    <strong>Author:</strong>
+    <%= story.author %>
+  </p>
+
+  <p>
+    <strong>External:</strong>
+    <%= story.external_id %>
+  </p>
+
+  <p>
+    <strong>Time:</strong>
+    <%= story.time %>
+  </p>
+
+  <h4> Users who picked this story </h4>
+  
+  <div> 
+    <% story.users.each do |user| %>
+      <%= user.first_name %>
+      <%= user.last_name %>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -1,0 +1,16 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Welcome to Top News</h1>
+<%= button_to "logout", destroy_user_session_path, method: :delete  %>
+
+<div id="stories">
+  <% @stories.each do |story| %>
+    <%= render story %>
+    <p>
+      <%= link_to "Show this story", story %>
+    </p>
+  <% end %>
+</div>
+
+
+

--- a/app/views/stories/index.json.jbuilder
+++ b/app/views/stories/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @stories, partial: "stories/story", as: :story

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -1,0 +1,8 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @story %>
+
+<div>
+  <%= button_to "Pick story", story_picked_path(@story), params: { id: @story } %> |
+  <%= link_to "Back to stories", stories_path %>
+</div>

--- a/app/views/stories/show.json.jbuilder
+++ b/app/views/stories/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "stories/story", story: @story

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: 'pages#home'
+
+  devise_scope :user do
+    root 'devise/sessions#new'
+  end
+
+  resources :stories, only: [:show, :index] do
+    post 'picked'
+  end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,10 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+every 1.day do
+  rake 'stories:create_stories'
+end
+
+

--- a/db/migrate/20230703142041_create_stories.rb
+++ b/db/migrate/20230703142041_create_stories.rb
@@ -1,0 +1,12 @@
+class CreateStories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :stories do |t|
+      t.text :title, null: false
+      t.string :author, null: false
+      t.integer :external_id, null: false, index: { unique: true }
+      t.integer :time, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230703165328_create_join_table_user_story.rb
+++ b/db/migrate/20230703165328_create_join_table_user_story.rb
@@ -1,0 +1,7 @@
+class CreateJoinTableUserStory < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :users, :stories, table_name: :picked_stories do |t|
+      t.index [:user_id, :story_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2018_02_28_212101) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_165328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "picked_stories", id: false, force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "story_id", null: false
+    t.index ["user_id", "story_id"], name: "index_picked_stories_on_user_id_and_story_id", unique: true
+  end
+
+  create_table "stories", force: :cascade do |t|
+    t.text "title", null: false
+    t.string "author", null: false
+    t.integer "external_id", null: false
+    t.integer "time", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["external_id"], name: "index_stories_on_external_id", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"

--- a/lib/tasks/stories.rake
+++ b/lib/tasks/stories.rake
@@ -1,0 +1,22 @@
+namespace :stories do
+  desc "TODO"
+  task create_stories: :environment do
+    logger.info 'hello'
+    client = HackerNewsApi::V1::Client.new
+    top_stories = client.top_stories
+    list_of_stories = []
+    
+    top_stories.each do |story_id|
+      story = client.find_story(story_id)
+      list_of_stories.push(story) if story["type"] == 'story'
+    end
+          
+    updated_stories = list_of_stories.map do |story| 
+      story.symbolize_keys.
+            transform_keys({id: :external_id, by: :author}).
+            except(:descendants, :kids, :score, :type, :text, :url) 
+    end
+    
+    Story.upsert_all(updated_stories, unique_by: :external_id)
+  end
+end

--- a/spec/models/picked_story_spec.rb
+++ b/spec/models/picked_story_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe PickedStory, type: :model do
+  context "creating a picked story" do
+    let(:picked_story_attrs) do 
+        { story_id: story, user_id: user }
+    end
+    let(:story_attrs) do
+      { title: 'story title', author: 'webber', external_id: 2, time: 3 }
+    end
+
+    let(:user_attrs) do
+      { first_name: :foo, last_name: :bar, email: 'f@b.c', password: 'foobar123' }
+    end
+
+    let(:story) { Story.create!(story_attrs) }
+    let(:user) { User.create!(user_attrs) }
+
+    it "should have user_id and story_id" do
+      expect { PickedStory.create!(user: user, story: story) }.to change{ PickedStory.count }.by(1)
+    end
+
+    it "should require a user_id" do
+      expect(PickedStory.new(picked_story_attrs.except(:user_id))).to be_invalid
+    end
+
+    it 'should not create a duplicate picked story' do
+      expect { PickedStory.create!(user: user, story: story) }.to change{ PickedStory.count }.by(1)
+      expect { PickedStory.create!(user: user, story: story) }.to raise_error(ActiveRecord::RecordInvalid,'Validation failed: Story user should not picked same story more than once')
+    end
+  end
+end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Story, type: :model do
+  context "creating a new story" do
+    let(:attrs) do
+      { title: 'story title', author: 'webber', external_id: 2, time: 3 }
+    end
+
+    it "should have title, author, external_id, and time" do
+      expect { Story.create!(attrs) }.to change{ Story.count }.by(1)
+    end
+
+    it "should require a external_id" do
+      expect(Story.new(attrs.except(:external_id))).to be_invalid
+    end
+
+    it 'should not create a duplicate story' do
+      expect { Story.create!(attrs) }.to change{ Story.count }.by(1)
+      expect { Story.create!(attrs) }.to raise_error(ActiveRecord::RecordInvalid,'Validation failed: External has already been taken')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe "/stories", type: :request do
+  let(:valid_attributes) {
+    { title: 'story title', author: 'webber', external_id: 2, time: 3 }
+  }
+
+  let(:user_attrs) do
+    { first_name: :foo, last_name: :bar, email: 'f@b.c', password: 'foobar123' }
+  end
+
+  let!(:story) { Story.create!(valid_attributes) }
+
+  before do
+    user = User.create!(user_attrs)
+    sign_in user
+  end
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      get stories_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /show" do
+    it "renders a successful response" do
+      get story_url(story)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /picked" do
+    it "render a successful response" do
+      params = {
+        id: story.id,
+        story_id: story.id,
+      }
+      expect(PickedStory.count).to eq(0)
+      post story_picked_url(params)
+      expect(response).to be_successful
+      expect(PickedStory.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/hacker_news_api_spec.rb
+++ b/spec/services/hacker_news_api_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe HackerNewsApi::V1::Client do
+  
+  before do
+    allow(HackerNewsApi::V1::Client).to receive(:new).and_return(client)
+  end
+  
+  describe '#top_stories' do
+    let(:client) { instance_double(HackerNewsApi::V1::Client, top_stories: api_response) }
+    let(:api_response) { [1, 3, 5] }
+
+    it 'should return a list of ids' do
+      expect(client.top_stories).to eq(api_response)
+    end
+  end
+
+  describe '#find_story' do
+  let(:client) { instance_double(HackerNewsApi::V1::Client, find_story: api_response) }
+    let(:story_id) { 4 }
+    let(:api_response) { 
+      {
+      "by"=>"pg", 
+      "descendants"=>15, 
+      "id"=>4, 
+      "kids"=>[15, 234509, 487171, 82729], 
+      "score"=>57, 
+      "time"=>1160418111, 
+      "title"=>"Y Combinator", 
+      "type"=>"story", 
+      "url"=>"http://ycombinator.com"
+      }
+    }
+
+    it 'should return a story' do
+      expect(client.find_story(story_id)).to include(api_response)
+    end
+  end
+end


### PR DESCRIPTION
# Top News Tool

## Pre Steps

1. After database migrations  run `bin/rake stories:create_stories` to hit API and save locally
2. Created a cron job using whenever gem to run rake task once per day.

## Story Details

- Top Stories will display all stories on the index page. 
- User will have to sign in to view the stories.
- Once a user visits the story they could clicked the picked button.
- The index of stories will show all the users who picked each story.
- Stories will be updated everyday.

Things I wish I could've done better 

- UI
- Error handling 
- Pagination
- Separate Picked stories to another page.

Please let me know if I am missing anything. Thank you again.