### PR TITLE
Preethi/yc feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,8 @@ gem 'turbolinks'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier'
 gem 'web-console', group: :development
+gem 'httparty'
+gem 'json'
+gem 'pry'
+
+gem "tailwindcss-rails", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,11 +105,15 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json (2.6.3)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -124,6 +128,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.16.3)
+    multi_xml (0.6.0)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -233,6 +238,8 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     strscan (3.0.4)
+    tailwindcss-rails (2.0.30)
+      railties (>= 6.0.0)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.0)
@@ -266,9 +273,12 @@ DEPENDENCIES
   capybara
   coffee-rails
   devise
+  httparty
   jbuilder
+  json
   listen
   pg
+  pry
   pry-rails
   puma
   rails (~> 7.0.3)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :authenticate_user!
+
+  add_flash_types :info, :error, :warning, :success
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
-
-  add_flash_types :info, :error, :warning, :success
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
   def home
-    @feed = YcConnector.new.build_feed
-    @liked_feed = Post.all
+    @page_count = params[:page_count] || 1
+    @feed = YcConnector.new.build_feed(page: @page_count.to_i)
+    @liked_feed = Post.all.order(:created_at).reverse_order
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,2 +1,6 @@
 class PagesController < ApplicationController
+  def home
+    @feed = YcConnector.new.build_feed
+    @liked_feed = Post.all
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,12 @@
 class PagesController < ApplicationController
   def home
     @page_count = params[:page_count] || 1
+
     @feed = YcConnector.new.build_feed(page: @page_count.to_i)
-    @liked_feed = Post.all.order(:created_at).reverse_order
+    @liked_feed = Post.joins(:user)
+                      .order(:created_at)
+                      .reverse_order
+                      .select(:item_id, :user_id, :title)
+                      .group_by(&:item_id)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,16 @@
+class PostsController < ApplicationController
+  def create
+    post = Post.find_or_create_by(
+      user_id: current_user.id,
+      title: params[:title],
+      url: params[:url],
+      item_id: params[:id])
+
+    flash[:success] = "Liked post!" if post.save!
+  rescue => e
+    flash[:alert] = "Something went wrong. Please try again."
+    Rails.logger.info(e.message)
+  ensure
+    redirect_to root_path
+  end
+end

--- a/app/helpers/page_helper.rb
+++ b/app/helpers/page_helper.rb
@@ -1,0 +1,13 @@
+module PageHelper
+  def item_list items
+    items.count > 2 ? items.first(2) : items
+  end
+
+  def count_verbiage items
+    items.count > 2 ? " & #{items.count - 2} #{'other'.pluralize}" : ""
+  end
+
+  def user_name_list items
+    item_list(items).map{|i| i.user.name}.join(", ") + count_verbiage(items)
+  end
+end

--- a/app/helpers/page_helper.rb
+++ b/app/helpers/page_helper.rb
@@ -4,7 +4,8 @@ module PageHelper
   end
 
   def count_verbiage items
-    items.count > 2 ? " & #{items.count - 2} #{'other'.pluralize}" : ""
+    reduced_count = items.count - 2
+    items.count > 2 ? " & #{reduced_count} #{'other'.pluralize(reduced_count)}" : ""
   end
 
   def user_name_list items

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,0 +1,2 @@
+module PostHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,5 @@
+class Post < ApplicationRecord
+  belongs_to :user
+
+  validates :user_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  def name
+    first_name + ' ' + last_name
+  end
 end

--- a/app/services/yc_connector.rb
+++ b/app/services/yc_connector.rb
@@ -1,0 +1,52 @@
+class YcConnector
+  include HTTParty
+  include JSON
+
+  def initialize type="top"
+    @feed_type = feed_type(type)
+  end
+
+  def get_stories
+    @item_ids ||= HTTParty.get("#{service_url}/#{@feed_type}.json")
+  end
+
+  def load_item item_id
+    HTTParty.get("#{service_url}/item/#{item_id}.json").body
+  end
+
+  def build_feed
+    item_ids = get_stories.first(10)
+    @feed = item_ids.map {|item_id| JSON.parse(load_item(item_id))}
+  end
+
+  private
+
+  def service_url
+    "https://hacker-news.firebaseio.com/v0/"
+  end
+
+  def feed_type ftype
+    case ftype
+    when "top"
+      "topstories"
+    when "best"
+      "beststories"
+    else
+      "newstories"
+    end
+  end
+
+  def set_last_item_fetched item_id
+    Redis.current.set("last_item_fetched", item_id)
+  end
+
+  def last_item_fetched
+    @item ||= Redis.current.get("last_item_fetched")
+  end
+end
+
+class YCConnectorError < StandardError
+  def initialize(message)
+    super(message)
+  end
+end

--- a/app/services/yc_connector.rb
+++ b/app/services/yc_connector.rb
@@ -7,7 +7,7 @@ class YcConnector
   end
 
   def get_stories
-    @item_ids ||= HTTParty.get("#{service_url}/#{@feed_type}.json")
+    @_item_ids ||= HTTParty.get("#{service_url}/#{@feed_type}.json")
   end
 
   def load_item item_id

--- a/app/services/yc_connector.rb
+++ b/app/services/yc_connector.rb
@@ -14,8 +14,8 @@ class YcConnector
     HTTParty.get("#{service_url}/item/#{item_id}.json").body
   end
 
-  def build_feed
-    item_ids = get_stories.first(10)
+  def build_feed(page:)
+    item_ids = get_stories[((10 * page) - 10)...10 * page]
     @feed = item_ids.map {|item_id| JSON.parse(load_item(item_id))}
   end
 
@@ -34,19 +34,5 @@ class YcConnector
     else
       "newstories"
     end
-  end
-
-  def set_last_item_fetched item_id
-    Redis.current.set("last_item_fetched", item_id)
-  end
-
-  def last_item_fetched
-    @item ||= Redis.current.get("last_item_fetched")
-  end
-end
-
-class YCConnectorError < StandardError
-  def initialize(message)
-    super(message)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
     <title>Top News</title>
     <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,1 +1,58 @@
-<h1>Welcome to Top News</h1>
+<div class="bg-white py-20 sm:py-24">
+  <% if flash[:success] %>
+    <div class="p-2 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:text-green-400" role="alert">
+      <span class="font-medium">Success!</span> <%= flash[:success] %>
+    </div>
+  <% elsif flash[:alert] %>
+    <div class="p-2 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:text-red-400" role="alert">
+      <span class="font-medium">Error!</span> <%= flash[:alert] %>
+    </div>
+  <% end %>
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <div class="mx-auto max-w-2xl lg:text-center">
+      <h2 class="text-base font-semibold leading-7 text-indigo-600">Hi <%= current_user.name %></h2>
+      <p class="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Welcome to Top News</p>
+      <%= button_to "Sign Out", destroy_user_session_path, method: :delete, class: "text-base font-semibold leading-7 text-red-300" %>
+    </div>
+    <div class="flex scroll-smooth mt-10">
+      <div class="basis-3/5 mr-2 pr-5 overflow-auto" style="max-height: 800px">
+        <h3 class="m-2 text-center font-bold"> Top YC News </h3>
+        <% @feed.each do |f| %>
+          <div class="h-32 rounded-lg bg-gray-100 p-2 mb-5">
+            <div class="relative pl-16">
+            <dt class="text-base font-semibold leading-7 text-gray-900">
+              <div class="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-600">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+                </svg>
+              </div>
+              Posted by <i><%= f["by"] %></i>
+              <%= link_to posts_path(f), method: :post, class: "absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg" do %>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" class="w-6 h-6 hover:fill-current hover:text-red-600">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+                </svg>
+              <% end %>
+            </dt>
+            <dd class="mt-2 text-base leading-7 text-gray-600"> <%= f["title"] %> </dd>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="basis-2/5 mx-5 overflow-auto" style="max-height: 800px">
+        <h3 class="m-2 text-center font-bold"> Liked Posts </h3>
+        <% @liked_feed.each do |f| %>
+          <div class="h-32 rounded-lg bg-gray-100 p-2 mb-5">
+            <div class="relative pl-16">
+            <dt class="text-base font-semibold leading-7 text-gray-900">
+              Liked by <i><%= f.user.name %></i>
+            </dt>
+            <dd class="mt-2 text-base leading-7 text-gray-600"> <%= f.title %> </dd>
+            </div>
+          </div>
+        <% end %>
+      </div>
+        
+    </div>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -58,13 +58,13 @@
 
       <div class="basis-2/5 mx-5 overflow-auto" style="max-height: 800px">
         <h3 class="m-2 text-center font-bold pb-6"> Liked Posts </h3>
-        <% @liked_feed.each do |f| %>
+        <% @liked_feed.each do |item_id, items| %>
           <div class="h-32 rounded-lg bg-gray-100 p-2 mb-5">
             <div class="relative pl-16">
             <dt class="text-base font-semibold leading-7 text-gray-900">
-              Liked by <i><%= f.user.name %></i>
+              Liked by <i><%= user_name_list(items) %></i>
             </dt>
-            <dd class="mt-2 text-base leading-7 text-gray-600"> <%= f.title %> </dd>
+            <dd class="mt-2 text-base leading-7 text-gray-600"> <%= items.first.title %> </dd>
             </div>
           </div>
         <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -15,8 +15,25 @@
       <%= button_to "Sign Out", destroy_user_session_path, method: :delete, class: "text-base font-semibold leading-7 text-red-300" %>
     </div>
     <div class="flex scroll-smooth mt-10">
+
       <div class="basis-3/5 mr-2 pr-5 overflow-auto" style="max-height: 800px">
         <h3 class="m-2 text-center font-bold"> Top YC News </h3>
+        
+        <div class="inline-flex">
+          <span class="mr-5"> Page: <%= @page_count %> </span> 
+          <%= link_to root_path(page_count: @page_count.to_i-1), method: :get, class: "hover:bg-gray-400" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 010-1.953l7.108-4.062A1.125 1.125 0 0121 8.688v8.123zM11.25 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 010-1.953L9.567 7.71a1.125 1.125 0 011.683.977v8.123z" />
+            </svg>
+          <% end %>
+
+          <%= link_to root_path(page_count: @page_count.to_i+1), method: :get, class: "hover:bg-gray-400" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 010 1.953l-7.108 4.062A1.125 1.125 0 013 16.81V8.688zM12.75 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 010 1.953l-7.108 4.062a1.125 1.125 0 01-1.683-.977V8.688z" />
+            </svg>
+          <% end %>
+        </div>
+        
         <% @feed.each do |f| %>
           <div class="h-32 rounded-lg bg-gray-100 p-2 mb-5">
             <div class="relative pl-16">
@@ -40,7 +57,7 @@
       </div>
 
       <div class="basis-2/5 mx-5 overflow-auto" style="max-height: 800px">
-        <h3 class="m-2 text-center font-bold"> Liked Posts </h3>
+        <h3 class="m-2 text-center font-bold pb-6"> Liked Posts </h3>
         <% @liked_feed.each do |f| %>
           <div class="h-32 rounded-lg bg-gray-100 p-2 mb-5">
             <div class="relative pl-16">

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
+
+  resources :posts, only: [:create]
 end

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,26 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  variants: {
+    fill: ['hover', 'focus'],
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/aspect-ratio'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ]
+}

--- a/db/migrate/20230812034516_create_posts.rb
+++ b/db/migrate/20230812034516_create_posts.rb
@@ -1,0 +1,12 @@
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.integer :item_id
+      t.integer :user_id
+      t.string :title
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2018_02_28_212101) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_12_034516) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.integer "item_id"
+    t.integer "user_id"
+    t.string "title"
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"

--- a/spec/controller/pages_controller_rspec.rb
+++ b/spec/controller/pages_controller_rspec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe PagesController, type: :controller do
+  describe "GET #home" do
+    it "assigns @page_count with default value" do
+      get :home
+      expect(assigns(:page_count)).to eq(1)
+    end
+
+    it "assigns @page_count with provided value" do
+      get :home, params: { page_count: 2 }
+      expect(assigns(:page_count)).to eq(2)
+    end
+
+    it "assigns @feed with a valid feed" do
+      yc_connector_mock = instance_double("YcConnector")
+      allow(YcConnector).to receive(:new).and_return(yc_connector_mock)
+      allow(yc_connector_mock).to receive(:build_feed).and_return("mocked_feed")
+
+      get :home
+      expect(assigns(:feed)).to eq("mocked_feed")
+    end
+
+    it "assigns @liked_feed with a list of posts" do
+      post1 = create(:post)
+      post2 = create(:post)
+      get :home
+      expect(assigns(:liked_feed)).to eq([post2, post1])
+    end
+
+    it "renders the home template" do
+      get :home
+      expect(response).to render_template(:home)
+    end
+  end
+end

--- a/spec/controller/posts_controller_rspec.rb
+++ b/spec/controller/posts_controller_rspec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe PostsController, type: :controller do
+  describe "POST #create" do
+    let(:user) { User.create!(email: "test@example.com", password: "123123") }
+    let(:valid_params) do
+      {
+        title: "Test Post",
+        url: "https://example.com",
+        id: 123
+      }
+    end
+    
+    context "when creating a post" do
+      before do
+        sign_in(user)
+      end
+
+      it "creates a new post" do
+        expect {
+          post :create, params: valid_params
+        }.to change(Post, :count).by(1)
+      end
+
+      it "redirects to root_path after creating" do
+        post :create, params: valid_params
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "sets a success flash message" do
+        post :create, params: valid_params
+        expect(flash[:success]).to eq("Liked post!")
+      end
+    end
+
+    context "when encountering an error" do
+      it "sets an alert flash message" do
+        allow_any_instance_of(Post).to receive(:save!).and_raise(StandardError)
+        post :create, params: valid_params
+        expect(flash[:alert]).to eq("Something went wrong. Please try again.")
+      end
+
+      it "logs the error message" do
+        allow_any_instance_of(Rails.logger).to receive(:info)
+        allow_any_instance_of(Post).to receive(:save!).and_raise(StandardError)
+        post :create, params: valid_params
+        expect(Rails.logger).to have_received(:info).with(anything)
+      end
+
+      it "redirects to root_path after encountering an error" do
+        allow_any_instance_of(Post).to receive(:save!).and_raise(StandardError)
+        post :create, params: valid_params
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  describe "validations" do
+    before { 
+      @post = described_class.new(
+      title: 'foo', 
+      url: 'https://example.com',
+      item_id: 1)
+      @user = User.create(email: "test@example.com", password: "123123")
+    }
+
+    it 'is valid with valid attributes' do
+      @post.user = @user
+      expect(@post).to be_valid
+    end
+    
+    it 'is invalid if the current_user is not available' do
+      expect{(@post.save!)}.to  raise_error(ActiveRecord::RecordInvalid,'Validation failed: User must exist, User can\'t be blank')
+    end
+  end
+
+  describe "associations" do
+    it "belongs to a user" do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :request do
+  describe "POST /posts" do
+    let(:user) {User.create!(email: "test@example.com", password: "123123")}
+
+    it "creates a new post" do
+      post_params = {
+        title: "This is the title of the new post.",
+        url: "http://www.example.com",
+        item_id: 12345
+      }
+      sign_in user
+
+      expect {
+        post "/posts", params: post_params
+      }.to change(Post, :count).by(1)
+
+      expect(response).to have_http_status(302)
+    end
+  end
+end

--- a/spec/services/yc_connector_spec.rb
+++ b/spec/services/yc_connector_spec.rb
@@ -1,0 +1,71 @@
+# spec/services/yc_connector_spec.rb
+
+require 'rails_helper'
+
+describe YcConnector do
+  describe "#initialize" do
+    it "sets @feed_type to 'topstories' by default" do
+      yc_connector = YcConnector.new
+      expect(yc_connector.instance_variable_get(:@feed_type)).to eq("topstories")
+    end
+
+    it "sets @feed_type based on the provided type" do
+      yc_connector = YcConnector.new("best")
+      expect(yc_connector.instance_variable_get(:@feed_type)).to eq("beststories")
+    end
+  end
+  
+  describe "#service_url" do
+    it "returns the correct service URL" do
+      yc_connector = YcConnector.new
+      expect(yc_connector.send(:service_url)).to eq("https://hacker-news.firebaseio.com/v0/")
+    end
+  end
+
+  describe "#get_stories" do
+    it "returns a list of item ids" do
+      yc_connector = YcConnector.new
+      allow(HTTParty).to receive(:get).and_return([1, 2, 3])
+      expect(yc_connector.get_stories).to eq([1, 2, 3])
+    end
+  end
+
+  describe "#load_item" do
+    it "returns the body of the HTTP response" do
+      yc_connector = YcConnector.new
+      allow(HTTParty).to receive(:get).and_return(double(body: "item_body"))
+      expect(yc_connector.load_item(123)).to eq("item_body")
+    end
+  end
+
+  describe "#build_feed" do
+    it "builds a feed based on item ids" do
+      yc_connector = YcConnector.new
+      allow(yc_connector).to receive(:get_stories).and_return([1, 2, 3])
+      allow(yc_connector).to receive(:load_item).and_return('{"title": "Test Title"}')
+      
+      feed = yc_connector.build_feed(page: 1)
+      
+      expect(feed).to be_instance_of(Array)
+      expect(feed.length).to eq(3)
+      expect(feed.first).to have_key("title")
+    end
+  end
+
+  describe "#feed_type" do
+    it "returns 'topstories' for type 'top'" do
+      yc_connector = YcConnector.new("top")
+      expect(yc_connector.send(:feed_type, "top")).to eq("topstories")
+    end
+
+    it "returns 'beststories' for type 'best'" do
+      yc_connector = YcConnector.new("best")
+      expect(yc_connector.send(:feed_type, "best")).to eq("beststories")
+    end
+
+    it "returns 'newstories' for unknown type" do
+      yc_connector = YcConnector.new("unknown")
+      expect(yc_connector.send(:feed_type, "unknown")).to eq("newstories")
+    end
+  end
+end


### PR DESCRIPTION
### Description

This pull request introduces new features in home page to list latest feed from YC, it also adds features for users to like posts that they enjoy. The home page also shares it's feed with recently liked posts, which is a feed built off posts that were liked by self/other users.

### Features
- User sign in/sign out
- Live feed from YC
- Liked feed (Posts liked by self/other users)
- Ability to like post

### Code Improvements

- **Simplified Feed Type Handling:** The `feed_type` method has been improved to handle feed types more efficiently. This simplification improves code clarity and maintainability.

- **Optimized URL Construction:** The `service_url` method has been optimized to construct service URLs using a consistent approach. This ensures the correct URL format and avoids redundancy. We have extracted YcConnection into a service object which can be easily extended without code 

### Added Test Cases

- **Initialization Testing:** Test cases have been added to validate the proper initialization of the `@feed_type` instance variable. This ensures that the default and provided feed types are set correctly.

- **Service URL Testing:** A test case has been included to verify that the `service_url` method returns the expected service URL.

- **Mocked HTTP Response Context:** The test context has been extended with mocked HTTP responses. This approach allows for thorough testing of the `get_stories`, `load_item`, and `build_feed` methods under controlled conditions.

### Potential Improvements

- Collect YC feed async using a Sidekiq worker
- Store YC feed to avoid making redundant requests
- Show Timestamps in Posts/Feed
- Liked Feed isn't paginated, could cause server overload as feed size increases

<img width="1427" alt="ss 15" src="https://github.com/fscbco/topnews/assets/7959875/9d083ae5-96c2-4d79-ab6f-ddcf76a57a09">

### Tophatting
- use command ./bin/dev to start server
- navigate to localhost:3000 to see the application live